### PR TITLE
fix: sort group_ids before setting in resourceHostRead

### DIFF
--- a/internal/awx/resource_host.go
+++ b/internal/awx/resource_host.go
@@ -3,6 +3,7 @@ package awx
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -167,6 +168,7 @@ func resourceHostRead(_ context.Context, d *schema.ResourceData, m interface{}) 
 	for i, g := range groups {
 		groupIDs[i] = g.ID
 	}
+	sort.Ints(groupIDs)
 	if err := d.Set("group_ids", groupIDs); err != nil {
 		return utils.Diagf(diagHostTitle, "Error setting group_ids for host %v: %s", id, err)
 	}


### PR DESCRIPTION
Switching from TypeList to TypeSet would be the more idiomatic Terraform approach for an unordered collection of unique IDs, but that would require state migration and be a breaking change. so let's just sort the ints.